### PR TITLE
Feature: show specific files first according to configuration

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { findParentModules } = require('./find-parent-modules');
 const { findChildPackages } = require('./find-child-packages');
 const { showError } = require('./utils');
+const { sortFiles } = require('./sort-files');
 
 var lastFolder = '';
 var lastWorkspaceName = '';
@@ -18,6 +19,7 @@ exports.activate = context => {
         const useLastFolder = preferences.get('useLastFolder', false);
         const nodeModulesPath = preferences.get('path', nodeModules);
         const searchParentModules = preferences.get('searchParentModules', true);
+        const orderPriority = preferences.get('orderPriority', []);
 
         const searchPath = (workspaceName, workspaceRoot, folderPath) => {
             // Path to node_modules in this workspace folder
@@ -42,7 +44,7 @@ exports.activate = context => {
                 }
 
                 const isParentFolder = folderPath.includes('..');
-                const options = files;
+                const options = sortFiles(files, orderPriority);
 
                 // If searching in root node_modules, also include modules from parent folders, that are outside of the workspace
                 if (folderPath === nodeModulesPath) {
@@ -64,6 +66,7 @@ exports.activate = context => {
 
                 vscode.window.showQuickPick(options, {
                     placeHolder: path.format({ dir: workspaceName, base: folderPath})
+
                 })
                 .then(selected => {
                     // node_modules shortcut selected

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Include modules from parent folders in search results."
+                },
+                "search-node-modules.orderPriority": {
+                    "type": "array",
+                    "default": ["index.js", "README.md", "package.json"],
+                    "description": "List of preferred names that should be shown at the top of the result list"
                 }
             }
         }

--- a/sort-files.js
+++ b/sort-files.js
@@ -1,0 +1,11 @@
+const sortFiles = (origFiles, origPriorities) => {
+    const priorities = [ ...origPriorities ].reverse().map(p => p.toLowerCase());
+    const files = origFiles.map(file => ({ original: file, lower: file.toLowerCase() }));
+    const rank = file => priorities.indexOf(file) + 1;
+
+    return files
+        .sort((a, b) => rank(b.lower) - rank(a.lower))
+        .map(file => file.original);
+};
+
+module.exports = { sortFiles };


### PR DESCRIPTION
(related to #7 )

It could be convenient to show preferred files at the top of the search results.

Before:
![image](https://user-images.githubusercontent.com/32811901/57301872-a4202280-70e2-11e9-9bb4-648450db3d23.png)


After:
![image](https://user-images.githubusercontent.com/32811901/57301825-88b51780-70e2-11e9-8a31-ff0d5ec149ae.png)


This PR create a new configuration field `search-node-modules.orderPriority`, which is a list of files to be shown first in the search results. 

The default value is `["index.js", "README.md", "package.json"]`, but each user may choose to customize it.

The list is ordered by priority, e.g. `index.js` will be shown before `readme.md`.