### PR TITLE
Suggestion: Add ability to search in parent folders

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,7 @@
 const vscode = require('vscode');
 const fs = require('fs');
 const path = require('path');
+const { findParentModules } = require('./find-parent-modules');
 
 var lastFolder = '';
 var lastWorkspaceName = '';
@@ -16,6 +17,7 @@ exports.activate = context => {
 
         const useLastFolder = preferences.get('useLastFolder', false);
         const nodeModulesPath = preferences.get('path', nodeModules);
+        const searchParentModules = preferences.get('searchParentModules', true);
 
         const searchPath = (workspaceName, workspaceRoot, folderPath) => {
             // Path to node_modules in this workspace folder
@@ -30,7 +32,7 @@ exports.activate = context => {
             const folderFullPath = path.join(workspaceRoot, folderPath);
 
             // Read folder, built quick pick with files/folder (and shortcuts)
-            fs.readdir(folderFullPath, (readErr, files) => {
+            fs.readdir(folderFullPath, async (readErr, files) => {
                 if (readErr) {
                     if (folderPath === nodeModulesPath) {
                         return showError('No node_modules folder in this workspace.');
@@ -39,14 +41,29 @@ exports.activate = context => {
                     return showError(`Unable to open folder ${folderPath}`);
                 }
 
-                if (folderPath !== nodeModulesPath) {
-                    files.push('');
-                    files.push(workspaceNodeModules);
-                    files.push('..');
+                const isParentFolder = folderPath.includes('..');
+                const options = files;
+
+                // If searching in root node_modules, also include modules from parent folders, that are outside of the workspace
+                if (folderPath === nodeModulesPath) {
+                    if (searchParentModules) {
+                        const parentModules = await findParentModules(workspaceRoot, nodeModulesPath);
+                        options.push(...parentModules);
+                    }
+                } else  {
+                    // Otherwise, show option to move back to root
+                    options.push('');
+                    options.push(workspaceNodeModules);
+
+                    // If current folder is not outside of the workspace, also add option to move a step back
+                    if (!isParentFolder) {
+                        options.push('..');
+                    }
                 }
 
-                vscode.window.showQuickPick(files, {
-                    placeHolder: path.join(workspaceName, folderPath)
+
+                vscode.window.showQuickPick(options, {
+                    placeHolder: path.format({ dir: workspaceName, base: folderPath})
                 })
                 .then(selected => {
                     // node_modules shortcut selected

--- a/find-parent-modules.js
+++ b/find-parent-modules.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path').posix;
+const util = require('util');
+
+const fsExists = util.promisify(fs.exists);
+const fsReaddir = util.promisify(fs.readdir);
+
+// Looks for node_modules in parent folders of the workspace recursively.
+// Returns a list of paths relative to workspaceRoot/nodeModulesPath
+const findParentModules = async (workspaceRoot, nodeModulesPath) => {
+    const absoluteRootNodeModules = path.join('/', nodeModulesPath);
+
+    const find = async dir => {
+        const ret = [];
+        if (await fsExists(dir)) {
+            const getFilePath = file =>
+                path.relative(path.join(workspaceRoot, nodeModulesPath), path.join(dir, file));
+
+            const dirFiles = await fsReaddir(dir);
+            ret.push(...dirFiles.map(getFilePath));
+        }
+
+        if (dir !== absoluteRootNodeModules) {
+            const parent = path.join(dir, '..', '..', nodeModulesPath);
+            ret.push(...(await find(parent)));
+        }
+
+        return ret;
+    };
+
+    return find(path.join(workspaceRoot, '..', nodeModulesPath));
+};
+
+module.exports = {
+    findParentModules
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
                     "type": "string",
                     "default": "node_modules",
                     "description": "Relative path to node_modules folder."
+                },
+                "search-node-modules.searchParentModules": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include modules from parent folders in search results."
                 }
             }
         }


### PR DESCRIPTION
### background ###
In #11 I attempted to solve the use-case of a user opening a monorepo with several projects, by allowing to search in any of them.

However, some users prefer not to open the entire monorepo, but rather only a single project from it - and I want to address this use-case as well. 

Since some node modules may be hoisted to the root level by lerna/yarn, they may be located outside the scope of the VSCode workspace, and the user can't find them.

My suggestion is to have the search results also include node_modules from parent directories.

![image](https://user-images.githubusercontent.com/32811901/57366350-7644e780-718f-11e9-9732-ed828a150ed2.png)


### details ###

consider the following structure of a monorepo:
```
root
├── lerna.json
├── node_modules
│   └── jquery
└── packages
    └── project-a
        ├── node_modules 
        │   └── jquery-ui
        └── src
```

The folder opened in VSCode is `/packages/project-a`. `jquery` is unfortunately out of scope for the search.

With this new feature, instead of only searching _under_ the workspace directory, the extension will also search _above_ it. i.e. Recursively traversing the directory tree upwards looking for `/node_modules`.

Note:
- All found node modules will include their relative path (e.g. `../../node_modules`) to indicate their non-trivial location.

- The parent modules will only be included when searching at the root level of the workspace, meaning that after a specific folder is selected for traversing, these extra modules will not appear.

- When traversing a specific module _from a parent folder_, the extra option to navigate back to `root/node_modules` will appear, but the extra option to step back (`..`) that is usually shown, will not be shown, since it will only take you further away from the workspace.

- You can opt out of this feature by turning off the new configuration field `searchParentModules`

- This feature can work together with the one suggested in #11. They are meant for different use-cases, and will not break each other

@jasonnutter 