### PR TITLE
Show directories suffixes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,7 @@ exports.activate = context => {
             const folderFullPath = path.join(workspaceRoot, folderPath);
 
             // Read folder, built quick pick with files/folder (and shortcuts)
-            fs.readdir(folderFullPath, async (readErr, files) => {
+            fs.readdir(folderFullPath, { withFileTypes: true }, async (readErr, files) => {
                 if (readErr) {
                     if (folderPath === nodeModulesPath) {
                         return showError('No node_modules folder in this workspace.');

--- a/extension.js
+++ b/extension.js
@@ -55,7 +55,7 @@ exports.activate = context => {
                 } else  {
                     // Otherwise, show option to move back to root
                     options.push('');
-                    options.push(`${workspaceNodeModules}/`);
+                    options.push(`${workspaceNodeModules}${path.sep}`);
 
                     // If current folder is not outside of the workspace, also add option to move a step back
                     if (!isParentFolder) {

--- a/extension.js
+++ b/extension.js
@@ -55,7 +55,7 @@ exports.activate = context => {
                 } else  {
                     // Otherwise, show option to move back to root
                     options.push('');
-                    options.push(workspaceNodeModules);
+                    options.push(`${workspaceNodeModules}/`);
 
                     // If current folder is not outside of the workspace, also add option to move a step back
                     if (!isParentFolder) {

--- a/sort-files.js
+++ b/sort-files.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const sortFiles = (origFiles, origPriorities) => {
     const priorities = [ ...origPriorities ].reverse().map(p => p.toLowerCase());
     const files = origFiles.map(file => ({ original: file, lower: file.name.toLowerCase() }));
@@ -6,7 +8,7 @@ const sortFiles = (origFiles, origPriorities) => {
     return files
         .sort((a, b) => rank(b.lower) - rank(a.lower))
         .map(({ original }) => original.isDirectory()
-            ? original.name + '/'
+            ? `${original.name}${path.sep}`
             : original.name);
 };
 

--- a/sort-files.js
+++ b/sort-files.js
@@ -1,11 +1,13 @@
 const sortFiles = (origFiles, origPriorities) => {
     const priorities = [ ...origPriorities ].reverse().map(p => p.toLowerCase());
-    const files = origFiles.map(file => ({ original: file, lower: file.toLowerCase() }));
+    const files = origFiles.map(file => ({ original: file, lower: file.name.toLowerCase() }));
     const rank = file => priorities.indexOf(file) + 1;
 
     return files
         .sort((a, b) => rank(b.lower) - rank(a.lower))
-        .map(file => file.original);
+        .map(({ original }) => original.isDirectory()
+            ? original.name + '/'
+            : original.name);
 };
 
 module.exports = { sortFiles };


### PR DESCRIPTION
This PR appends a platform-specific path separator suffix (`/` for Unixes and `\` for Windows) to every **directory** within the current selected package making easier to tell which items are traversable or just plain files:

**Before**:

![before](https://user-images.githubusercontent.com/1379779/62940577-2d2ab200-bdd4-11e9-82dd-665790ddc4f8.png)

**After**:

![after](https://user-images.githubusercontent.com/1379779/62940592-33209300-bdd4-11e9-820f-51f435b41207.png)